### PR TITLE
Push the JSONdoc zip to gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
+
+after_success:
+    - ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Possible scenarios are flooding or coordinating support for political refugees.
 
 This is only a REST API for the server. The frontend is not part of this repository. For usage please care about the
 LICENSE file.
- 
+
 ## Setup
 
 1. Fork the repository for development. Implementations can be submitted by a Pull-Request.
@@ -36,6 +36,8 @@ Check <a href="http://localhost:8080/jsondoc-ui.html">http://localhost:8080/json
 the api. The playground is enabled to submit json objects easily.
 
 <pre>mvn clean package -Pdistributable</pre> creates an offline api documentation in target/jsondoc-distribution.zip.
+
+If you are only interested in the JSONdoc documentation, you can download it at [here](helfenkannjeder.github.io/come2help-server/jsondoc-distribution.zip).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the api. The playground is enabled to submit json objects easily.
 
 <pre>mvn clean package -Pdistributable</pre> creates an offline api documentation in target/jsondoc-distribution.zip.
 
-If you are only interested in the JSONdoc documentation, you can download it at [here](helfenkannjeder.github.io/come2help-server/jsondoc-distribution.zip).
+If you are only interested in the JSONdoc documentation, you can download it [here](helfenkannjeder.github.io/come2help-server/jsondoc-distribution.zip).
 
 ## Contact
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# If GH_TOKEN is not set, we'll exit gracefully
+if [ -z ${GH_TOKEN:+1} ]; then
+	echo "The GH_TOKEN ENV is not set. Thus, we'll won't deploy to gh-pages"
+	exit 0
+fi
+
+set -e # exit with nonzero exit code if anything fails
+
+# Create an empty deploy directory. Any data that's going to be deployed shall be in there.
+mkdir -p deploy
+
+# Create the JSONdoc zip
+mvn package -Pdistributable -Dmaven.test.skip=true -Dfindbugs.skip=true
+
+echo
+echo
+
+# Copy the jsondoc zip to the deply directory
+cp target/jsondoc-distribution.zip deploy
+
+# go to the deploy directory and create a *new* Git repo
+cd deploy
+git init
+
+# inside this git repo we'll pretend to be a new user
+git config user.name "Travis CI"
+git config user.email "travis@come2.help"
+
+# The first and only commit to this new Git repo contains all the
+# files present with the commit message "Deploy to GitHub Pages".
+git add .
+git commit -m "Deploy to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" master:gh-pages > /dev/null 2>&1
+
+# Restore PWD
+cd $OLDPWD

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+	echo "We won't deploy because we're on a pull request."
+	exit 0
+fi
+
 # If GH_TOKEN is not set, we'll exit gracefully
 if [ -z ${GH_TOKEN:+1} ]; then
-	echo "The GH_TOKEN ENV is not set. Thus, we'll won't deploy to gh-pages"
+	echo "The GH_TOKEN ENV is not set. Thus, we'll won't deploy to gh-pages."
 	exit 0
 fi
 


### PR DESCRIPTION
The JSONdoc distributable zip will be pushed to the `gh-pages` branch of the source repository on GitHub if a Travis build succeeds.

To enable the automatic deploying for a repository, do the following:

 1. Go to your [GitHub Personal Access Tokens Settings Page](https://github.com/settings/tokens)
 2. Create a token (I guess the `repo` right is enough) and copy it.
 3. Go to your repo on Travis. Go to Settings. 
 4. Create the Environment variable `GH_TOKEN`. *Make sure to leave "Display value in build log" off!*. Paste the GitHub token as value.

Note that the script won't deploy on pull requests – which makes sense, if you think of it.