### PR TITLE
Introduce login form for OAuth 2.0 login provider (common/oauth2-provider)

### DIFF
--- a/server/src/main/java/de/helfenkannjeder/come2help/server/security/jwt/HelfenkannjederSuccessHandler.java
+++ b/server/src/main/java/de/helfenkannjeder/come2help/server/security/jwt/HelfenkannjederSuccessHandler.java
@@ -1,0 +1,32 @@
+package de.helfenkannjeder.come2help.server.security.jwt;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class HelfenkannjederSuccessHandler extends JwtCreatingAuthenticationSuccessHandler {
+
+    @Override
+    protected String providerIdentifier() {
+        return "google";
+    }
+
+    @Override
+    protected String surnameField() {
+        return "family_name";
+    }
+
+    @Override
+    protected String givenNameField() {
+        return "given_name";
+    }
+
+    @Override
+    protected String emailField() {
+        return "email";
+    }
+
+    @Override
+    protected String idField() {
+        return "id";
+    }
+}

--- a/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/CustomOAuthAuthenticationProcessingFilter.java
+++ b/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/CustomOAuthAuthenticationProcessingFilter.java
@@ -1,0 +1,44 @@
+package de.helfenkannjeder.come2help.server.security.oauth2;
+
+import de.helfenkannjeder.come2help.server.configuration.security.ClientResourceDetails;
+import de.helfenkannjeder.come2help.server.security.oauth2.token.AccessTokenService;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomOAuthAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
+
+    private final UserInfoTokenServices tokenService;
+    private final AccessTokenService accessTokenService;
+
+    public CustomOAuthAuthenticationProcessingFilter(String path, ClientResourceDetails clientResourceDetails, AccessTokenService accessTokenService) {
+        super(path);
+        this.tokenService = new UserInfoTokenServices(clientResourceDetails.getResource().getUserInfoUri(), clientResourceDetails.getClient().getClientId());
+        this.accessTokenService = accessTokenService;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        if (!"POST".equals(request.getMethod())) {
+            throw new BadCredentialsException("Only POST allowed.");
+        }
+
+        OAuth2AccessToken accessToken = accessTokenService.getAccessToken(request);
+
+        try {
+            return tokenService.loadAuthentication(accessToken.getValue());
+        } catch (InvalidTokenException e) {
+            throw new BadCredentialsException("Could not obtain user details from token", e);
+        }
+    }
+
+}

--- a/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/OAuth2Client.java
+++ b/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/OAuth2Client.java
@@ -1,0 +1,44 @@
+package de.helfenkannjeder.come2help.server.security.oauth2;
+
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.token.AccessTokenRequest;
+import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import java.util.List;
+
+/**
+ * @author Valentin Zickner
+ */
+public class OAuth2Client {
+
+    private static final String GRANT_TYPE = "password";
+
+    private final String tokenUrl;
+    private final String clientId;
+    private final String secret;
+
+    public OAuth2Client(String tokenUrl, String clientId, String secret) {
+        this.tokenUrl = tokenUrl;
+        this.clientId = clientId;
+        this.secret = secret;
+    }
+
+    public OAuth2AccessToken getAccessToken(String username, String password, List<String> scopes) {
+        ResourceOwnerPasswordResourceDetails resource = new ResourceOwnerPasswordResourceDetails();
+
+        resource.setAccessTokenUri(tokenUrl);
+        resource.setClientId(clientId);
+        resource.setClientSecret(secret);
+        resource.setGrantType(GRANT_TYPE);
+        resource.setScope(scopes);
+
+        resource.setUsername(username);
+        resource.setPassword(password);
+
+        AccessTokenRequest atr = new DefaultAccessTokenRequest();
+        return new OAuth2RestTemplate(resource, new DefaultOAuth2ClientContext(atr)).getAccessToken();
+    }
+}

--- a/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/token/AccessTokenService.java
+++ b/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/token/AccessTokenService.java
@@ -1,0 +1,15 @@
+package de.helfenkannjeder.come2help.server.security.oauth2.token;
+
+import de.helfenkannjeder.come2help.server.configuration.security.ClientResourceDetails;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * @author Valentin Zickner
+ */
+public interface AccessTokenService {
+    void setClientResourceDetails(ClientResourceDetails clientResourceDetails);
+    OAuth2AccessToken getAccessToken(HttpServletRequest httpServletRequest) throws IOException;
+}

--- a/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/token/PasswordAccessTokenService.java
+++ b/server/src/main/java/de/helfenkannjeder/come2help/server/security/oauth2/token/PasswordAccessTokenService.java
@@ -1,0 +1,59 @@
+package de.helfenkannjeder.come2help.server.security.oauth2.token;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.helfenkannjeder.come2help.server.configuration.security.ClientResourceDetails;
+import de.helfenkannjeder.come2help.server.security.oauth2.OAuth2Client;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * @author Valentin Zickner
+ */
+public class PasswordAccessTokenService implements AccessTokenService {
+
+    private final ObjectMapper objectMapper;
+    private ClientResourceDetails clientResourceDetails;
+
+    public PasswordAccessTokenService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void setClientResourceDetails(ClientResourceDetails clientResourceDetails) {
+        this.clientResourceDetails = clientResourceDetails;
+    }
+
+    @Override
+    public OAuth2AccessToken getAccessToken(HttpServletRequest request) throws IOException {
+        LoginInformation loginInformation = objectMapper.readValue(request.getReader(), LoginInformation.class);
+        OAuth2Client client = new OAuth2Client(clientResourceDetails.getClient().getAccessTokenUri(),
+                clientResourceDetails.getClient().getClientId(),
+                clientResourceDetails.getClient().getClientSecret());
+        return client.getAccessToken(loginInformation.getEmail(),
+                loginInformation.getPassword(), Collections.singletonList("default"));
+    }
+
+    private static class LoginInformation {
+        private String email;
+        private String password;
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -65,8 +65,15 @@ google:
         userInfoUri: https://www.googleapis.com/oauth2/v2/userinfo
         preferTokenInfo: false
         
-        
-        
+
+helfenkannjeder:
+    client:
+        clientId: come2help-web
+        clientSecret: secret
+        accessTokenUri: http://localhost:8081/oauth/token
+    resource:
+        userInfoUri: http://localhost:8081/user/information
+
         
 api:
     jwt:

--- a/web-frontend/index.html
+++ b/web-frontend/index.html
@@ -49,9 +49,24 @@
 				<ul class="nav navbar-nav">
 					<li ng-class="ctrl.getClass('/imprint')"><a href="#/imprint">{{ 'Imprint' | translate }}</a></li>
 				</ul>
-				<ul class="nav navbar-nav navbar-right" ng-show="ctrl.authenticated()">
-					<li><a href="" ng-click="ctrl.logout()">{{ 'Logout' | translate }}</a></li>
-				</ul>
+				<div class="navbar-right" data-ng-controller="NavigationController as ctrl">
+					<form class="navbar-form" data-ng-hide="ctrl.authenticated()" data-ng-submit="ctrl.login()">
+						<div class="form-group">
+							<label class="sr-only" for="login-email">{{ 'Email' | translate}}</label>
+							<input type="email" class="form-control" id="login-email" data-ng-model="ctrl.user.email"
+								   placeholder="{{ 'Email' | translate}}">
+						</div>
+						<div class="form-group">
+							<label class="sr-only" for="login-password">{{ 'Password' | translate}}</label>
+							<input type="password" class="form-control col-xs-4" id="login-password"
+								   data-ng-model="ctrl.user.password" placeholder="{{ 'Password' | translate }}">
+						</div>
+						<button type="submit" class="btn btn-default btn-success">{{ 'Log in' | translate }}</button>
+					</form>
+					<button type="button" href="" data-ng-click="ctrl.logout()" class="btn navbar-btn btn-link"
+							data-ng-show="ctrl.authenticated()">{{ 'Logout' | translate }}
+					</button>
+				</div>
 			</div>
 		</div>
 	</nav>

--- a/web-frontend/js/authProvider.js
+++ b/web-frontend/js/authProvider.js
@@ -1,7 +1,7 @@
 angular.module('Come2HelpApp').config(['$authProvider', function ($authProvider) {
 
 	$authProvider.signupUrl = '/api/volunteers';
-	$authProvider.loginUrl = '/api/login/volunteer';
+	$authProvider.loginUrl = '/api/login/helfenkannjeder';
 
 	$authProvider.facebook({
 		clientId: '417693555105063',

--- a/web-frontend/js/controllers/NavigationController.js
+++ b/web-frontend/js/controllers/NavigationController.js
@@ -1,17 +1,37 @@
 angular.module('Come2HelpApp')
-.controller('NavigationController', ['jwtService', '$location', function(jwtService, $location) {
-	var vm = this;
+	.controller('NavigationController', ['jwtService', '$location', '$auth', function (jwtService, $location, $auth) {
+		var vm = this;
 
-	vm.authenticated = jwtService.isAuthenticated.bind(jwtService);
-	vm.isGuest = jwtService.isGuest.bind(jwtService);
-	vm.isOrganisation = jwtService.isOrganisation.bind(jwtService);
-	vm.logout = jwtService.logout;
+		vm.user = {};
+		vm.authenticated = jwtService.isAuthenticated.bind(jwtService);
+		vm.isGuest = jwtService.isGuest.bind(jwtService);
+		vm.isOrganisation = jwtService.isOrganisation.bind(jwtService);
+		vm.logout = jwtService.logout;
 
-	vm.getClass = function (path) {
-		if ($location.path().substr(0, path.length) === path) {
-			return 'active';
-		} else {
-			return '';
-		}
-	};
-}]);
+		vm.credentials = {};
+
+		vm.login = function() {
+			// user transport object
+			var transUser = {
+				email: vm.user.email || '',
+				password: vm.user.password || ''
+			};
+			console.log(transUser);
+
+			$auth.login(transUser)
+				.then(function () {
+					// Do nothing, global handling do everything
+				})
+				.catch(function () {
+					alert('login error');
+				});
+		};
+
+		vm.getClass = function (path) {
+			if ($location.path().substr(0, path.length) === path) {
+				return 'active';
+			} else {
+				return '';
+			}
+		};
+	}]);

--- a/web-frontend/test/behaviour/register.js
+++ b/web-frontend/test/behaviour/register.js
@@ -45,7 +45,7 @@ function signupWith(data) {
 	}
 
 	// Submit
-	$('button[type="submit"]').click();
+	$('.panel-body button[type="submit"]').click();
 }
 
 /**


### PR DESCRIPTION
This branch integrates the OAuth 2.0 provider.
- Use satellizer form login to execute the login against the backend (come2help)
- Add new handler for the form login to parse username and password
- Execute OAuth 2.0 password request against the OAuth 2.0 provider (provided by common)
- Continue with normal flow like on other OAuth 2.0 authentication providers.

This pull request is still work in progress:
- Error handling is missing
- Unit testing for form reading, ...
